### PR TITLE
Persist job start Time to database.

### DIFF
--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/FilterableMantisJobMetadataWritable.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/FilterableMantisJobMetadataWritable.java
@@ -39,6 +39,7 @@ public class FilterableMantisJobMetadataWritable extends MantisJobMetadataWritab
                                                @JsonProperty("name") String name,
                                                @JsonProperty("user") String user,
                                                @JsonProperty("submittedAt") long submittedAt,
+                                               @JsonProperty("startedAt") long startedAt,
                                                @JsonProperty("jarUrl") URL jarUrl,
                                                @JsonProperty("numStages") int numStages,
                                                @JsonProperty("sla") JobSla sla,
@@ -48,7 +49,7 @@ public class FilterableMantisJobMetadataWritable extends MantisJobMetadataWritab
                                                @JsonProperty("nextWorkerNumberToUse") int nextWorkerNumberToUse,
                                                @JsonProperty("migrationConfig") WorkerMigrationConfig migrationConfig,
                                                @JsonProperty("labels") List<Label> labels) {
-        super(jobId, name, user, submittedAt, jarUrl, numStages, sla, state, subscriptionTimeoutSecs,
+        super(jobId, name, user, submittedAt, startedAt, jarUrl, numStages, sla, state, subscriptionTimeoutSecs,
                 parameters, nextWorkerNumberToUse, migrationConfig, labels);
     }
 

--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/IMantisJobMetadata.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/IMantisJobMetadata.java
@@ -37,7 +37,7 @@ import io.mantisrx.server.master.persistence.exceptions.InvalidJobException;
  */
 public interface IMantisJobMetadata {
 
-    long NOT_SET = 0;
+    long DEFAULT_STARTED_AT_EPOCH = 0;
 
     /**
      * Returns the {@link JobId}.

--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/IMantisJobMetadata.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/IMantisJobMetadata.java
@@ -37,6 +37,8 @@ import io.mantisrx.server.master.persistence.exceptions.InvalidJobException;
  */
 public interface IMantisJobMetadata {
 
+    long NOT_SET = 0;
+
     /**
      * Returns the {@link JobId}.
      * @return

--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -1013,8 +1013,8 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                 // kick off max runtime timer if needed
 
                 Instant currentTime = Instant.now();
-                //this.subscriptionTracker.onJobStart();
-                mantisJobMetaData.setStartedAt(currentTime.toEpochMilli());
+                // Update start time and persist state
+                mantisJobMetaData.setStartedAt(currentTime.toEpochMilli(), jobStore);
 
                 setRuntimeLimitTimersIfRequired(currentTime);
 
@@ -1111,6 +1111,10 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
         LOGGER.trace("Exit JobActor::updateStateAndPersist for Job {}", jobId);
     }
 
+    /**
+     * Always invoked after the job has transitioned to started state.
+     * @param currentTime
+     */
     private void setRuntimeLimitTimersIfRequired(Instant currentTime) {
 
         long maxRuntimeSecs = mantisJobMetaData.getJobDefinition().getJobSla().getRuntimeLimitSecs();

--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/MantisJobMetadataImpl.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/MantisJobMetadataImpl.java
@@ -22,7 +22,6 @@ import java.time.Instant;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
-import io.mantisrx.master.jobcluster.job.worker.IMantisWorkerMetadata;
 import io.mantisrx.master.jobcluster.job.worker.JobWorker;
 import io.mantisrx.server.master.domain.DataFormatAdapter;
 import org.slf4j.Logger;
@@ -50,8 +49,8 @@ public class MantisJobMetadataImpl implements IMantisJobMetadata {
     private static final Logger logger = LoggerFactory.getLogger(MantisJobMetadataImpl.class);
     private final JobId jobId;
     private final long submittedAt;
-    private long startedAt = NOT_SET;
-    private long endedAt = NOT_SET;
+    private long startedAt = DEFAULT_STARTED_AT_EPOCH;
+    private long endedAt = DEFAULT_STARTED_AT_EPOCH;
 
     private JobState state;
     private int nextWorkerNumberToUse;
@@ -327,7 +326,7 @@ public class MantisJobMetadataImpl implements IMantisJobMetadata {
   
    	@Override
 	public Optional<Instant> getStartedAtInstant() {
-		if(this.startedAt == NOT_SET) {
+		if(this.startedAt == DEFAULT_STARTED_AT_EPOCH) {
 		    return Optional.empty();
 		} else {
 		    return Optional.of(Instant.ofEpochMilli(startedAt));
@@ -341,7 +340,7 @@ public class MantisJobMetadataImpl implements IMantisJobMetadata {
 
 	@Override
 	public Optional<Instant> getEndedAtInstant() {
-	    if(this.endedAt == NOT_SET) {
+	    if(this.endedAt == DEFAULT_STARTED_AT_EPOCH) {
             return Optional.empty();
         } else {
             return Optional.of(Instant.ofEpochMilli(endedAt));

--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/MantisJobMetadataImpl.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/MantisJobMetadataImpl.java
@@ -50,8 +50,8 @@ public class MantisJobMetadataImpl implements IMantisJobMetadata {
     private static final Logger logger = LoggerFactory.getLogger(MantisJobMetadataImpl.class);
     private final JobId jobId;
     private final long submittedAt;
-    private long startedAt = -1;
-    private long endedAt = -1;
+    private long startedAt = NOT_SET;
+    private long endedAt = NOT_SET;
 
     private JobState state;
     private int nextWorkerNumberToUse;
@@ -327,7 +327,7 @@ public class MantisJobMetadataImpl implements IMantisJobMetadata {
   
    	@Override
 	public Optional<Instant> getStartedAtInstant() {
-		if(this.startedAt == -1 || this.startedAt == 0) {
+		if(this.startedAt == NOT_SET) {
 		    return Optional.empty();
 		} else {
 		    return Optional.of(Instant.ofEpochMilli(startedAt));
@@ -335,23 +335,23 @@ public class MantisJobMetadataImpl implements IMantisJobMetadata {
 		
 	}
    	
-   	public long getStartedAt() {
+	public long getStartedAt() {
    	    return this.startedAt;
    	}
 
 	@Override
 	public Optional<Instant> getEndedAtInstant() {
-	    if(this.endedAt == -1) {
+	    if(this.endedAt == NOT_SET) {
             return Optional.empty();
         } else {
             return Optional.of(Instant.ofEpochMilli(endedAt));
         }
 	}
 
-    public long getEndedAt() {
+	public long getEndedAt() {
         return this.endedAt;
     }
-	
+
     public static class Builder {
     	JobId jobId;
         

--- a/server/src/main/java/io/mantisrx/server/master/domain/DataFormatAdapter.java
+++ b/server/src/main/java/io/mantisrx/server/master/domain/DataFormatAdapter.java
@@ -65,6 +65,7 @@ import rx.functions.Func2;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -444,7 +445,7 @@ public class DataFormatAdapter {
         }
 
         // generate job meta
-        MantisJobMetadataImpl mantisJobMetadata = new MantisJobMetadataImpl(jIdOp.get(), archJob.getSubmittedAt(), jobDefn, convertMantisJobStateToJobState(archJob.getState()), archJob.getNextWorkerNumberToUse());
+        MantisJobMetadataImpl mantisJobMetadata = new MantisJobMetadataImpl(jIdOp.get(), archJob.getSubmittedAt(), archJob.getStartedAt(), jobDefn, convertMantisJobStateToJobState(archJob.getState()), archJob.getNextWorkerNumberToUse());
 
 
         // add the stages
@@ -519,10 +520,12 @@ public class DataFormatAdapter {
 
     public static MantisJobMetadataWritable convertMantisJobMetadataToMantisJobMetadataWriteable(IMantisJobMetadata jobMetadata) {
 
+        long startedAt = (jobMetadata.getStartedAtInstant().isPresent()) ? jobMetadata.getStartedAtInstant().get().toEpochMilli() : -1;
         return new MantisJobMetadataWritable(jobMetadata.getJobId().getId(),
                 jobMetadata.getJobId().getCluster(),
                 jobMetadata.getUser(),
                 jobMetadata.getSubmittedAtInstant().toEpochMilli(),
+                startedAt,
                 jobMetadata.getJobJarUrl(),
                 jobMetadata.getTotalStages(),
                 jobMetadata.getSla().orElse(null),
@@ -536,11 +539,12 @@ public class DataFormatAdapter {
     }
 
     public static FilterableMantisJobMetadataWritable convertMantisJobMetadataToFilterableMantisJobMetadataWriteable(IMantisJobMetadata jobMetadata) {
-
+        long startedAt = (jobMetadata.getStartedAtInstant().isPresent()) ? jobMetadata.getStartedAtInstant().get().toEpochMilli() : -1;
         return new FilterableMantisJobMetadataWritable(jobMetadata.getJobId().getId(),
                 jobMetadata.getJobId().getCluster(),
                 jobMetadata.getUser(),
                 jobMetadata.getSubmittedAtInstant().toEpochMilli(),
+                startedAt,
                 jobMetadata.getJobJarUrl(),
                 jobMetadata.getTotalStages(),
                 jobMetadata.getSla().orElse(null),

--- a/server/src/main/java/io/mantisrx/server/master/domain/DataFormatAdapter.java
+++ b/server/src/main/java/io/mantisrx/server/master/domain/DataFormatAdapter.java
@@ -438,14 +438,18 @@ public class DataFormatAdapter {
         Optional<String> artifactName = extractArtifactName(jarUrl);
 
         // generate job defn
-        JobDefinition jobDefn = new JobDefinition(archJob.getName(), archJob.getUser(), artifactName.orElse(""), null,archJob.getParameters(), archJob.getSla(), archJob.getSubscriptionTimeoutSecs(),schedulingInfo, archJob.getNumStages(),archJob.getLabels());
+        JobDefinition jobDefn = new JobDefinition(archJob.getName(), archJob.getUser(),
+                artifactName.orElse(""), null,archJob.getParameters(), archJob.getSla(),
+                archJob.getSubscriptionTimeoutSecs(),schedulingInfo, archJob.getNumStages(),archJob.getLabels());
         Optional<JobId> jIdOp = JobId.fromId(archJob.getJobId());
         if(!jIdOp.isPresent()) {
             throw new IllegalArgumentException("Invalid JobId " + archJob.getJobId());
         }
 
         // generate job meta
-        MantisJobMetadataImpl mantisJobMetadata = new MantisJobMetadataImpl(jIdOp.get(), archJob.getSubmittedAt(), archJob.getStartedAt(), jobDefn, convertMantisJobStateToJobState(archJob.getState()), archJob.getNextWorkerNumberToUse());
+        MantisJobMetadataImpl mantisJobMetadata = new MantisJobMetadataImpl(jIdOp.get(), archJob.getSubmittedAt(),
+                archJob.getStartedAt(), jobDefn, convertMantisJobStateToJobState(archJob.getState()),
+                archJob.getNextWorkerNumberToUse());
 
 
         // add the stages
@@ -454,12 +458,16 @@ public class DataFormatAdapter {
         }
 
 
-        if(logger.isTraceEnabled()) { logger.trace("DataFormatAdapter:Completed conversion to IMantisJobMetadata {}", mantisJobMetadata); }
+        if(logger.isTraceEnabled()) { logger.trace("DataFormatAdapter:Completed conversion to IMantisJobMetadata {}",
+                mantisJobMetadata); }
         return mantisJobMetadata;
     }
 
     private static StageSchedulingInfo generateStageSchedulingInfo(IMantisStageMetadata mantisStageMetadata) {
-        StageSchedulingInfo stageSchedulingInfo = new StageSchedulingInfo(mantisStageMetadata.getNumWorkers(),mantisStageMetadata.getMachineDefinition(),mantisStageMetadata.getHardConstraints(),mantisStageMetadata.getSoftConstraints(),mantisStageMetadata.getScalingPolicy(),mantisStageMetadata.getScalable());
+        StageSchedulingInfo stageSchedulingInfo = new StageSchedulingInfo(mantisStageMetadata.getNumWorkers(),
+                mantisStageMetadata.getMachineDefinition(),mantisStageMetadata.getHardConstraints(),
+                mantisStageMetadata.getSoftConstraints(),mantisStageMetadata.getScalingPolicy(),
+                mantisStageMetadata.getScalable());
         return stageSchedulingInfo;
     }
 
@@ -479,10 +487,11 @@ public class DataFormatAdapter {
         return schedulingInfo;
     }
 
-    public static IMantisStageMetadata convertMantisStageMetadataWriteableToMantisStageMetadata(MantisStageMetadata stageMeta,
-                                                                                                LifecycleEventPublisher eventPublisher
-                                                                                                ) {
-        return convertMantisStageMetadataWriteableToMantisStageMetadata(stageMeta,eventPublisher,false);
+    public static IMantisStageMetadata convertMantisStageMetadataWriteableToMantisStageMetadata(
+            MantisStageMetadata stageMeta,
+            LifecycleEventPublisher eventPublisher) {
+        return convertMantisStageMetadataWriteableToMantisStageMetadata(stageMeta,eventPublisher,
+                false);
     }
 
     public static IMantisStageMetadata convertMantisStageMetadataWriteableToMantisStageMetadata(MantisStageMetadata stageMeta,
@@ -520,12 +529,12 @@ public class DataFormatAdapter {
 
     public static MantisJobMetadataWritable convertMantisJobMetadataToMantisJobMetadataWriteable(IMantisJobMetadata jobMetadata) {
 
-        long startedAt = (jobMetadata.getStartedAtInstant().isPresent()) ? jobMetadata.getStartedAtInstant().get().toEpochMilli() : -1;
+        Instant startedAtInstant = jobMetadata.getStartedAtInstant().orElse(Instant.ofEpochMilli(0));
         return new MantisJobMetadataWritable(jobMetadata.getJobId().getId(),
                 jobMetadata.getJobId().getCluster(),
                 jobMetadata.getUser(),
                 jobMetadata.getSubmittedAtInstant().toEpochMilli(),
-                startedAt,
+                startedAtInstant.toEpochMilli(),
                 jobMetadata.getJobJarUrl(),
                 jobMetadata.getTotalStages(),
                 jobMetadata.getSla().orElse(null),
@@ -539,12 +548,12 @@ public class DataFormatAdapter {
     }
 
     public static FilterableMantisJobMetadataWritable convertMantisJobMetadataToFilterableMantisJobMetadataWriteable(IMantisJobMetadata jobMetadata) {
-        long startedAt = (jobMetadata.getStartedAtInstant().isPresent()) ? jobMetadata.getStartedAtInstant().get().toEpochMilli() : -1;
+        Instant startedAtInstant = jobMetadata.getStartedAtInstant().orElse(Instant.ofEpochMilli(0));
         return new FilterableMantisJobMetadataWritable(jobMetadata.getJobId().getId(),
                 jobMetadata.getJobId().getCluster(),
                 jobMetadata.getUser(),
                 jobMetadata.getSubmittedAtInstant().toEpochMilli(),
-                startedAt,
+                startedAtInstant.toEpochMilli(),
                 jobMetadata.getJobJarUrl(),
                 jobMetadata.getTotalStages(),
                 jobMetadata.getSla().orElse(null),

--- a/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadata.java
+++ b/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadata.java
@@ -29,6 +29,8 @@ import io.mantisrx.runtime.parameter.Parameter;
 
 public interface MantisJobMetadata {
 
+    long NOT_SET = 0;
+
     String getJobId();
 
     String getName();

--- a/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadata.java
+++ b/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadata.java
@@ -29,7 +29,7 @@ import io.mantisrx.runtime.parameter.Parameter;
 
 public interface MantisJobMetadata {
 
-    long NOT_SET = 0;
+    long DEFAULT_STARTED_AT_EPOCH = 0;
 
     String getJobId();
 

--- a/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadata.java
+++ b/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadata.java
@@ -37,6 +37,8 @@ public interface MantisJobMetadata {
 
     long getSubmittedAt();
 
+    long getStartedAt();
+
     URL getJarUrl();
 
     JobSla getSla();

--- a/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
+++ b/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 public class MantisJobMetadataWritable implements MantisJobMetadata {
 
     private static final Logger logger = LoggerFactory.getLogger(MantisJobMetadataWritable.class);
+
     private final String user;
     private final JobSla sla;
     private final long subscriptionTimeoutSecs;
@@ -57,7 +58,7 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
     private String jobId;
     private String name;
     private long submittedAt;
-    private long startedAt = -1;
+    private long startedAt = NOT_SET;
     private URL jarUrl;
     private volatile MantisJobState state;
     private int numStages;
@@ -86,9 +87,8 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
         this.name = name;
         this.user = user;
         this.submittedAt = submittedAt;
-        if(startedAt == 0) {
-            this.startedAt = submittedAt;
-        }
+        this.startedAt = startedAt;
+
         this.jarUrl = jarUrl;
         this.numStages = numStages;
         this.sla = sla;

--- a/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
+++ b/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
@@ -57,6 +57,7 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
     private String jobId;
     private String name;
     private long submittedAt;
+    private long startedAt = -1;
     private URL jarUrl;
     private volatile MantisJobState state;
     private int numStages;
@@ -71,6 +72,7 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
                                      @JsonProperty("name") String name,
                                      @JsonProperty("user") String user,
                                      @JsonProperty("submittedAt") long submittedAt,
+                                     @JsonProperty("startedAt") long startedAt,
                                      @JsonProperty("jarUrl") URL jarUrl,
                                      @JsonProperty("numStages") int numStages,
                                      @JsonProperty("sla") JobSla sla,
@@ -84,6 +86,9 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
         this.name = name;
         this.user = user;
         this.submittedAt = submittedAt;
+        if(startedAt == 0) {
+            this.startedAt = submittedAt;
+        }
         this.jarUrl = jarUrl;
         this.numStages = numStages;
         this.sla = sla;
@@ -135,6 +140,9 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
     public long getSubmittedAt() {
         return submittedAt;
     }
+
+    @Override
+    public long getStartedAt() { return startedAt;}
 
     @Override
     public URL getJarUrl() {
@@ -258,96 +266,25 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
         return max;
     }
 
-    public static class OldJobMetadataImpl {
-
-        private final String jobId;
-        private final String name;
-        private final long submittedAt;
-        private final URL jarUrl;
-        private final int numStages;
-        private final SlaType slaType;
-        private final MantisJobDurationType durationType;
-        private final String userProvidedType;
-        private final List<Parameter> parameters;
-        private final MantisJobState state;
-        @JsonCreator
-        @JsonIgnoreProperties(ignoreUnknown = true)
-        public OldJobMetadataImpl(@JsonProperty("jobId") String jobId, @JsonProperty("name") String name,
-                                  @JsonProperty("submittedAt") long submittedAt,
-                                  @JsonProperty("jarUrl") URL jarUrl,
-                                  @JsonProperty("numStages") int numStages,
-                                  @JsonProperty("slaType") SlaType slaType,
-                                  @JsonProperty("durationType") MantisJobDurationType durationType,
-                                  @JsonProperty("userProvidedType") String userProvidedType,
-                                  @JsonProperty("parameters") List<Parameter> parameters,
-                                  @JsonProperty("state") MantisJobState state) {
-            this.jobId = jobId;
-            this.name = name;
-            this.submittedAt = submittedAt;
-            this.jarUrl = jarUrl;
-            this.numStages = numStages;
-            this.slaType = slaType;
-            this.durationType = durationType;
-            this.userProvidedType = userProvidedType;
-            this.parameters = parameters;
-            this.state = state;
-        }
-
-        public String getJobId() {
-            return jobId;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public long getSubmittedAt() {
-            return submittedAt;
-        }
-
-        public URL getJarUrl() {
-            return jarUrl;
-        }
-
-        public int getNumStages() {
-            return numStages;
-        }
-
-        public SlaType getSlaType() {
-            return slaType;
-        }
-
-        public MantisJobDurationType getDurationType() {
-            return durationType;
-        }
-
-        public String getUserProvidedType() {
-            return userProvidedType;
-        }
-
-        public List<Parameter> getParameters() {
-            return parameters;
-        }
-
-        public MantisJobState getState() {
-            return state;
-        }
-
-        public enum SlaType {
-            Lossy
-        }
+    @Override
+    public String toString() {
+        return "MantisJobMetadataWritable{" +
+                "user='" + user + '\'' +
+                ", sla=" + sla +
+                ", subscriptionTimeoutSecs=" + subscriptionTimeoutSecs +
+                ", labels=" + labels +
+                ", stageMetadataMap=" + stageMetadataMap +
+                ", workerNumberToStageMap=" + workerNumberToStageMap +
+                ", jobId='" + jobId + '\'' +
+                ", name='" + name + '\'' +
+                ", submittedAt=" + submittedAt +
+                ", startedAt=" + startedAt +
+                ", jarUrl=" + jarUrl +
+                ", state=" + state +
+                ", numStages=" + numStages +
+                ", parameters=" + parameters +
+                ", nextWorkerNumberToUse=" + nextWorkerNumberToUse +
+                ", migrationConfig=" + migrationConfig +
+                '}';
     }
-
-    class Locker implements AutoCloseable {
-
-        public Locker() {
-            lock.lock();
-        }
-
-        @Override
-        public void close() throws Exception {
-            lock.unlock();
-        }
-    }
-
 }

--- a/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
+++ b/server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.mantisrx.common.Label;
 import io.mantisrx.runtime.JobSla;
-import io.mantisrx.runtime.MantisJobDurationType;
 import io.mantisrx.runtime.MantisJobState;
 import io.mantisrx.runtime.WorkerMigrationConfig;
 import io.mantisrx.runtime.parameter.Parameter;
@@ -58,7 +57,7 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
     private String jobId;
     private String name;
     private long submittedAt;
-    private long startedAt = NOT_SET;
+    private long startedAt = DEFAULT_STARTED_AT_EPOCH;
     private URL jarUrl;
     private volatile MantisJobState state;
     private int numStages;

--- a/server/src/test/java/io/mantisrx/master/jobcluster/JobClusterTest.java
+++ b/server/src/test/java/io/mantisrx/master/jobcluster/JobClusterTest.java
@@ -2082,7 +2082,7 @@ public class JobClusterTest {
 
             verify(jobStoreMock, times(6)).updateWorker(any());
 
-            verify(jobStoreMock, times(2)).updateJob(any());
+            verify(jobStoreMock, times(3)).updateJob(any());
 
             // initial worker and scale up worker
             verify(schedulerMock, times(3)).scheduleWorker(any());

--- a/server/src/test/java/io/mantisrx/master/jobcluster/job/JobScaleUpDownTests.java
+++ b/server/src/test/java/io/mantisrx/master/jobcluster/job/JobScaleUpDownTests.java
@@ -128,7 +128,7 @@ public class JobScaleUpDownTests {
 
 		verify(jobStoreMock, times(6)).updateWorker(any());
 
-		verify(jobStoreMock, times(2)).updateJob(any());
+		verify(jobStoreMock, times(3)).updateJob(any());
 
 		// initial worker + job master and scale up worker
 		verify(schedulerMock, times(3)).scheduleWorker(any());
@@ -170,7 +170,7 @@ public class JobScaleUpDownTests {
 		// 9 for worker events + 1 for scale down
 		verify(jobStoreMock, times(10)).updateWorker(any());
 
-		verify(jobStoreMock, times(2)).updateJob(any());
+		verify(jobStoreMock, times(3)).updateJob(any());
 
 		// 1 scale down
 		verify(schedulerMock, times(1)).unscheduleAndTerminateWorker(any(), any());
@@ -511,7 +511,7 @@ SchedulingChange [jobId=testSchedulingInfo-1, workerAssignments={
 
 		verify(jobStoreMock, times(3)).updateWorker(any());
 
-		verify(jobStoreMock, times(2)).updateJob(any());
+		verify(jobStoreMock, times(3)).updateJob(any());
 
 		// initial worker only
 		verify(schedulerMock, times(1)).scheduleWorker(any());
@@ -554,7 +554,7 @@ SchedulingChange [jobId=testSchedulingInfo-1, workerAssignments={
 
 		verify(jobStoreMock, times(3)).updateWorker(any());
 
-		verify(jobStoreMock, times(2)).updateJob(any());
+		verify(jobStoreMock, times(3)).updateJob(any());
 
 		// initial worker only
 		verify(schedulerMock, times(1)).scheduleWorker(any());

--- a/server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
+++ b/server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
@@ -204,7 +204,7 @@ public class JobTestLifecycle {
 			
 			verify(jobStoreMock, times(3)).updateWorker(any());
 			
-			verify(jobStoreMock, times(2)).updateJob(any());
+			verify(jobStoreMock, times(3)).updateJob(any());
 
 			//assertEquals(jobActor, probe.getLastSender());
 		} catch (InvalidJobException  e) {
@@ -298,7 +298,9 @@ public class JobTestLifecycle {
 
             verify(jobStoreMock, times(3)).updateWorker(any());
 
-            verify(jobStoreMock, times(2)).updateJob(any());
+            verify(jobStoreMock, times(3)).updateJob(any());
+
+			//verify(jobStoreMock, times(3))
 
             verify(schedulerMock,times(1)).scheduleWorker(any());
 
@@ -443,7 +445,7 @@ public class JobTestLifecycle {
 			
 			verify(jobStoreMock, times(6)).updateWorker(any());
 			
-			verify(jobStoreMock, times(2)).updateJob(any());
+			verify(jobStoreMock, times(3)).updateJob(any());
 			
 			//assertEquals(jobActor, probe.getLastSender());
 		} catch (InvalidJobException  e) {
@@ -572,7 +574,7 @@ public class JobTestLifecycle {
 
 			verify(jobStoreMock, times(19)).updateWorker(any());
 
-			verify(jobStoreMock, times(2)).updateJob(any());
+			verify(jobStoreMock, times(3)).updateJob(any());
 
 			//assertEquals(jobActor, probe.getLastSender());
 		} catch (InvalidJobException  e) {
@@ -677,7 +679,7 @@ public class JobTestLifecycle {
 
 			verify(jobStoreMock, times(6)).updateWorker(any());
 
-			verify(jobStoreMock, times(2)).updateJob(any());
+			verify(jobStoreMock, times(3)).updateJob(any());
 
 			//assertEquals(jobActor, probe.getLastSender());
 		} catch (InvalidJobException  e) {
@@ -1031,7 +1033,9 @@ public class JobTestLifecycle {
 		
 		//MantisJobMetadataImpl mantisJobMetaMock = mock(MantisJobMetadataImpl.class);
 		JobDefinition jobDefnMock = mock(JobDefinition.class);
-		MantisJobMetadataImpl mantisJobMeta = new MantisJobMetadataImpl(JobId.fromId("job-1").get(), Instant.now().toEpochMilli(), jobDefnMock, JobState.Accepted, 0);
+		MantisJobMetadataImpl mantisJobMeta = new MantisJobMetadataImpl(JobId.fromId("job-1").get(),
+				Instant.now().toEpochMilli(),Instant.now().toEpochMilli(), jobDefnMock, JobState.Accepted,
+				0);
 
 		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 		WorkerNumberGenerator wng = new WorkerNumberGenerator();

--- a/server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
+++ b/server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
@@ -695,5 +695,5 @@ public class DataFormatAdapterTest {
 
 
     }
-    
+
 }

--- a/server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
+++ b/server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
@@ -695,6 +695,5 @@ public class DataFormatAdapterTest {
 
 
     }
-
-
+    
 }

--- a/server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
+++ b/server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
@@ -16,7 +16,12 @@
 
 package io.mantisrx.server.master.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.Lists;
 import io.mantisrx.common.Label;
@@ -690,7 +695,6 @@ public class DataFormatAdapterTest {
 
 
     }
-
 
 
 }


### PR DESCRIPTION
### Context

Job start time was not being persisted to the data store. As a result on a Mantis Master restart for jobs with runtime limit the accurate time remaining to run could not be calculated. This PR updates the data model to store/retrieve and use the startedAt time.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
