### PR TITLE
Use enum values instead of names for labels, add copyright headers

### DIFF
--- a/server/src/main/java/io/mantisrx/master/jobcluster/LabelManager.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/LabelManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.mantisrx.master.jobcluster;
 
 import java.util.ArrayList;
@@ -47,13 +63,13 @@ public class LabelManager {
 
         // remove old artifact & version label if present.
         List<Label> updatedLabels = labels.stream()
-                .filter(label -> !(label.getName().equals(SystemLabels.MANTIS_ARTIFACT_LABEL.name())))
-                .filter(label -> !label.getName().equals(SystemLabels.MANTIS_VERSION_LABEL.name()))
+                .filter(label -> !(label.getName().equals(SystemLabels.MANTIS_ARTIFACT_LABEL.label)))
+                .filter(label -> !label.getName().equals(SystemLabels.MANTIS_VERSION_LABEL.label))
                 .collect(Collectors.toList());
 
-        updatedLabels.add(new Label(SystemLabels.MANTIS_ARTIFACT_LABEL.name(), artifactName));
+        updatedLabels.add(new Label(SystemLabels.MANTIS_ARTIFACT_LABEL.label, artifactName));
 
-        updatedLabels.add(new Label(SystemLabels.MANTIS_VERSION_LABEL.name(), version));
+        updatedLabels.add(new Label(SystemLabels.MANTIS_VERSION_LABEL.label, version));
 
         try {
             updatedJobDefn = new JobDefinition.Builder().from(updatedJobDefn)
@@ -70,11 +86,11 @@ public class LabelManager {
         List<Label> labels = resolvedJobDefn.getLabels();
 
         boolean alreadyHasResubmitLabel = labels.stream().anyMatch(
-                label -> label.getName().equals(SystemLabels.MANTIS_IS_RESUBMIT_LABEL.name()));
+                label -> label.getName().equals(SystemLabels.MANTIS_IS_RESUBMIT_LABEL.label));
 
         if(!alreadyHasResubmitLabel) {
             List<Label> updatedLabels = new ArrayList<>(labels);
-            updatedLabels.add(new Label(SystemLabels.MANTIS_IS_RESUBMIT_LABEL.name(), "true"));
+            updatedLabels.add(new Label(SystemLabels.MANTIS_IS_RESUBMIT_LABEL.label, "true"));
             try {
                 JobDefinition updatedJobDefn = new JobDefinition.Builder().from(resolvedJobDefn)
                         .withLabels(updatedLabels).build();

--- a/server/src/test/java/io/mantisrx/master/jobcluster/LabelManagerTest.java
+++ b/server/src/test/java/io/mantisrx/master/jobcluster/LabelManagerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.mantisrx.master.jobcluster;
 
 import static io.mantisrx.master.jobcluster.LabelManager.SystemLabels.*;
@@ -25,19 +41,19 @@ public class LabelManagerTest {
         JobDefinition updatedJobDefn = LabelManager.insertAutoResubmitLabel(jobDefinition);
         assertEquals(1, updatedJobDefn.getLabels().size());
         Label label = updatedJobDefn.getLabels().get(0);
-        assertEquals(MANTIS_IS_RESUBMIT_LABEL.name(), label.getName());
+        assertEquals(MANTIS_IS_RESUBMIT_LABEL.label, label.getName());
     }
 
     @Test
     public void doNotinsertResubmitLabelIfAlreadyExistsTest() throws InvalidJobException {
         List<Label> labels = new ArrayList<>();
-        labels.add(new Label(MANTIS_IS_RESUBMIT_LABEL.name(), "true"));
+        labels.add(new Label(MANTIS_IS_RESUBMIT_LABEL.label, "true"));
         JobDefinition jobDefinition = generateJobDefinition("DoNotinsertResubmitLabelIfAlreadyExistsTest",
                 labels, "art.zip", "1.0");
         JobDefinition updatedJobDefn = LabelManager.insertAutoResubmitLabel(jobDefinition);
         assertEquals(1, updatedJobDefn.getLabels().size());
         Label label = updatedJobDefn.getLabels().get(0);
-        assertEquals(MANTIS_IS_RESUBMIT_LABEL.name(), label.getName());
+        assertEquals(MANTIS_IS_RESUBMIT_LABEL.label, label.getName());
     }
 
     @Test
@@ -49,11 +65,11 @@ public class LabelManagerTest {
         assertEquals(2, updatedJobDefn.getLabels().size());
 
         List<Label> labels = updatedJobDefn.getLabels().stream().filter(
-                label -> label.getName().equals(MANTIS_ARTIFACT_LABEL.name()))
+                label -> label.getName().equals(MANTIS_ARTIFACT_LABEL.label))
                 .collect(Collectors.toList());
 
         Label label = labels.get(0);
-        assertEquals(MANTIS_ARTIFACT_LABEL.name(), label.getName());
+        assertEquals(MANTIS_ARTIFACT_LABEL.label, label.getName());
         assertEquals(artifactName, label.getValue());
     }
 
@@ -61,19 +77,19 @@ public class LabelManagerTest {
     public void replaceArtifactLabelTest() throws InvalidJobException {
         String artifactName = "art1.zip";
         List<Label> labels = new ArrayList<>();
-        labels.add(new Label(MANTIS_ARTIFACT_LABEL.name(), "art0.zip"));
+        labels.add(new Label(MANTIS_ARTIFACT_LABEL.label, "art0.zip"));
         JobDefinition jobDefinition = generateJobDefinition("replaceArtifactLabelTest", labels,
                 artifactName, "1.0");
         JobDefinition updatedJobDefn = LabelManager.insertSystemLabels(jobDefinition, false);
         assertEquals(2, updatedJobDefn.getLabels().size());
 
         labels = updatedJobDefn.getLabels().stream().filter(
-                label -> label.getName().equals(MANTIS_ARTIFACT_LABEL.name()))
+                label -> label.getName().equals(MANTIS_ARTIFACT_LABEL.label))
                 .collect(Collectors.toList());
 
         Label label = labels.get(0);
 
-        assertEquals(MANTIS_ARTIFACT_LABEL.name(), label.getName());
+        assertEquals(MANTIS_ARTIFACT_LABEL.label, label.getName());
         assertEquals(artifactName, label.getValue());
     }
 
@@ -86,11 +102,11 @@ public class LabelManagerTest {
         assertEquals(2, updatedJobDefn.getLabels().size());
 
         List<Label> labels = updatedJobDefn.getLabels().stream().filter(
-                label -> label.getName().equals(MANTIS_VERSION_LABEL.name()))
+                label -> label.getName().equals(MANTIS_VERSION_LABEL.label))
                 .collect(Collectors.toList());
 
         Label label = labels.get(0);
-        assertEquals(MANTIS_VERSION_LABEL.name(), label.getName());
+        assertEquals(MANTIS_VERSION_LABEL.label, label.getName());
         assertEquals("1.0", label.getValue());
     }
 
@@ -100,19 +116,19 @@ public class LabelManagerTest {
         String v0 = "1.0";
         String v1 = "2.0";
         List<Label> labels = new ArrayList<>();
-        labels.add(new Label(MANTIS_VERSION_LABEL.name(), v0));
+        labels.add(new Label(MANTIS_VERSION_LABEL.label, v0));
         JobDefinition jobDefinition = generateJobDefinition("replaceVersionLabelTest", labels,
                 artifactName, "2.0");
         JobDefinition updatedJobDefn = LabelManager.insertSystemLabels(jobDefinition, false);
         assertEquals(2, updatedJobDefn.getLabels().size());
 
         labels = updatedJobDefn.getLabels().stream().filter(
-                label -> label.getName().equals(MANTIS_VERSION_LABEL.name()))
+                label -> label.getName().equals(MANTIS_VERSION_LABEL.label))
                 .collect(Collectors.toList());
 
         Label label = labels.get(0);
 
-        assertEquals(MANTIS_VERSION_LABEL.name(), label.getName());
+        assertEquals(MANTIS_VERSION_LABEL.label, label.getName());
         assertEquals(v1, label.getValue());
     }
 
@@ -120,15 +136,15 @@ public class LabelManagerTest {
     public void systemLabelTest() throws InvalidJobException {
         String artifactName = "art1.zip";
         List<Label> labels = new ArrayList<>();
-        labels.add(new Label(MANTIS_ARTIFACT_LABEL.name(), "art0.zip"));
+        labels.add(new Label(MANTIS_ARTIFACT_LABEL.label, "art0.zip"));
         JobDefinition jobDefinition = generateJobDefinition("systemLabelTest", labels,
                 artifactName,"1.0");
         JobDefinition updatedJobDefn = LabelManager.insertSystemLabels(jobDefinition, true);
         assertEquals(3, updatedJobDefn.getLabels().size());
         for(Label l : updatedJobDefn.getLabels()) {
-            if(l.getName().equals(MANTIS_ARTIFACT_LABEL.name())) {
+            if(l.getName().equals(MANTIS_ARTIFACT_LABEL.label)) {
                 assertEquals(artifactName, l.getValue());
-            } else if (l.getName().equals(MANTIS_IS_RESUBMIT_LABEL.name())){
+            } else if (l.getName().equals(MANTIS_IS_RESUBMIT_LABEL.label)){
                 assertEquals("true", l.getValue());
             } else {
                 assertEquals("1.0", l.getValue());
@@ -153,4 +169,6 @@ public class LabelManagerTest {
 
                 .build();
     }
+
+
 }


### PR DESCRIPTION
### Context

Use the label enum values instead of the enum name itself. Add copy right headers.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
