### PR TITLE
API to return latest Job's discovery info (a.k.a. schedulingInfo) for a job cluster

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -25,7 +25,7 @@ ext {
     hdrHistogramVersion = '2.+'
     jodaTimeVersion = '2.+'
     jsonVersion = '20180813'
-    mantisVersion = '1.+'
+    mantisVersion = '1.2.+'
     mesosVersion = '1.0.1'
     rxJavaReactiveStreamsVersion = '1.+'
     testngVersion = '6.14.+'
@@ -60,16 +60,5 @@ dependencies {
 
     testCompile "com.typesafe.akka:akka-testkit_2.12:$akkaVersion"
     testCompile "junit:junit:4.+"
-    testCompile "org.testng:testng:6.+"
     testCompile "org.mockito:mockito-all:2.+"
-}
-
-task testNG(type: Test) {
-    useTestNG() {
-        suites 'src/test/resources/testng.xml'
-    }
-}
-
-test {
-    dependsOn testNG
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -46,3 +46,12 @@ run {
     standardInput = System.in
 }
 
+task testNG(type: Test) {
+    useTestNG() {
+        suites 'src/test/resources/testng.xml'
+    }
+}
+
+test {
+    dependsOn testNG
+}

--- a/server/src/main/java/io/mantisrx/master/IJobClustersManager.java
+++ b/server/src/main/java/io/mantisrx/master/IJobClustersManager.java
@@ -65,6 +65,8 @@ public interface IJobClustersManager {
 
     void onGetJobStatusSubject(JobClusterManagerProto.GetJobSchedInfoRequest request);
 
+    void onGetLatestJobDiscoveryInfo(JobClusterManagerProto.GetLatestJobDiscoveryInfoRequest request);
+
     void onJobListCompleted(JobClusterManagerProto.ListCompletedJobsInClusterRequest r);
     
     void onJobList(ListJobsRequest request);

--- a/server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
@@ -155,7 +155,7 @@ public class MasterApiAkkaService extends BaseService {
         final AgentClusterRoute v0AgentClusterRoute = new AgentClusterRoute(agentClusterOperations, actorSystem);
         final JobStatusRoute v0JobStatusRoute = new JobStatusRoute(jobStatusRouteHandler);
 
-        final JobClustersRoute v1JobClusterRoute = new JobClustersRoute(jobClusterRouteHandler);
+        final JobClustersRoute v1JobClusterRoute = new JobClustersRoute(jobClusterRouteHandler, actorSystem);
         final JobsRoute v1JobsRoute = new JobsRoute(jobClusterRouteHandler, jobRouteHandler);
         final AdminMasterRoute v1AdminMasterRoute = new AdminMasterRoute(masterDescription);
         final AgentClustersRoute v1AgentClustersRoute = new AgentClustersRoute(agentClusterOperations);

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobClusterRouteHandler.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobClusterRouteHandler.java
@@ -43,5 +43,7 @@ public interface JobClusterRouteHandler {
 
     CompletionStage<JobClusterManagerProto.GetJobClusterResponse> getJobClusterDetails(final JobClusterManagerProto.GetJobClusterRequest request);
 
+    CompletionStage<JobClusterManagerProto.GetLatestJobDiscoveryInfoResponse> getLatestJobDiscoveryInfo(final JobClusterManagerProto.GetLatestJobDiscoveryInfoRequest request);
+
     CompletionStage<JobClusterManagerProto.ListJobClustersResponse> getAllJobClusters(final JobClusterManagerProto.ListJobClustersRequest request);
 }

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobClusterRouteHandlerAkkaImpl.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobClusterRouteHandlerAkkaImpl.java
@@ -134,4 +134,10 @@ public class JobClusterRouteHandlerAkkaImpl implements JobClusterRouteHandler {
             .thenApply(JobClusterManagerProto.ListJobClustersResponse.class::cast);
         return response;
     }
+
+    @Override
+    public CompletionStage<JobClusterManagerProto.GetLatestJobDiscoveryInfoResponse> getLatestJobDiscoveryInfo(JobClusterManagerProto.GetLatestJobDiscoveryInfoRequest request) {
+        CompletionStage<JobClusterManagerProto.GetLatestJobDiscoveryInfoResponse> response = ask(jobClustersManagerActor, request, timeout)
+            .thenApply(JobClusterManagerProto.GetLatestJobDiscoveryInfoResponse.class::cast);
+        return response;    }
 }

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
@@ -22,17 +22,29 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import akka.actor.ActorSystem;
+import akka.http.caching.LfuCache;
+import akka.http.caching.javadsl.Cache;
+import akka.http.caching.javadsl.CachingSettings;
+import akka.http.caching.javadsl.LfuCacheSettings;
 import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.HttpEntities;
 import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.HttpMethods;
+import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.model.Uri;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.ExceptionHandler;
+import akka.http.javadsl.server.RequestContext;
 import akka.http.javadsl.server.Route;
+import akka.http.javadsl.server.RouteResult;
 import akka.http.javadsl.server.directives.RouteAdapter;
+import akka.japi.JavaPartialFunction;
 import akka.japi.pf.PFBuilder;
 import akka.pattern.AskTimeoutException;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -47,6 +59,7 @@ import io.mantisrx.master.api.akka.route.MasterApiMetrics;
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.concurrent.duration.Duration;
 
 
 abstract class BaseRoute extends AllDirectives {
@@ -63,6 +76,18 @@ abstract class BaseRoute extends AllDirectives {
     private static final Iterable<HttpHeader> DEFAULT_RESPONSE_HEADERS =
             Arrays.asList(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER);
 
+    protected final JavaPartialFunction<RequestContext, Uri> getRequestUriKeyer = new JavaPartialFunction<RequestContext, Uri>() {
+        public Uri apply(RequestContext in, boolean isCheck) {
+            final HttpRequest request = in.getRequest();
+            final boolean isGet = request.method() == HttpMethods.GET;
+            if (isGet) {
+                return request.getUri();
+            } else {
+                throw noMatch();
+            }
+        }
+    };
+
     private String hostName;
 
     BaseRoute() {
@@ -73,6 +98,15 @@ abstract class BaseRoute extends AllDirectives {
         }
     }
 
+    protected Cache<Uri, RouteResult> createCache(ActorSystem actorSystem, int initialCapacity, int maxCapacity, int ttlMillis) {
+        final CachingSettings defaultCachingSettings = CachingSettings.create(actorSystem);
+        final LfuCacheSettings lfuCacheSettings = defaultCachingSettings.lfuCacheSettings()
+            .withInitialCapacity(initialCapacity)
+            .withMaxCapacity(maxCapacity)
+            .withTimeToLive(Duration.create(ttlMillis, TimeUnit.MILLISECONDS));
+        final CachingSettings cachingSettings = defaultCachingSettings.withLfuCacheSettings(lfuCacheSettings);
+        return LfuCache.create(cachingSettings);
+    }
 
     protected abstract Route constructRoutes();
 
@@ -242,7 +276,7 @@ abstract class BaseRoute extends AllDirectives {
         node.put("requestId", requestId);
         return node.toString();
     }
-    
+
     FilterProvider parseFilter(String fields, String target) {
         if (Strings.isNullOrEmpty(fields)) {
             return null;

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/v1/HttpRequestMetrics.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/v1/HttpRequestMetrics.java
@@ -36,6 +36,7 @@ public class HttpRequestMetrics {
     public static class Endpoints {
         public static final String JOB_CLUSTERS = "api.v1.jobClusters";
         public static final String JOB_CLUSTER_INSTANCE = "api.v1.jobClusters.instance";
+        public static final String JOB_CLUSTER_INSTANCE_LATEST_JOB_DISCOVERY_INFO = "api.v1.jobClusters.instance.latestJobDiscoveryInfo";
         public static final String JOB_CLUSTER_INSTANCE_ACTION_UPDATE_ARTIFACT = "api.v1.jobClusters.instance.actions.updateArtifact";
         public static final String JOB_CLUSTER_INSTANCE_ACTION_UPDATE_SLA = "api.v1.jobClusters.instance.actions.updateSla";
         public static final String JOB_CLUSTER_INSTANCE_ACTION_UPDATE_MIGRATION_STRATEGY = "api.v1.jobClusters.instance.actions.updateMigrationStrategy";
@@ -64,6 +65,7 @@ public class HttpRequestMetrics {
         private static String[] endpoints = new String[]{
                 JOB_CLUSTERS,
                 JOB_CLUSTER_INSTANCE,
+                JOB_CLUSTER_INSTANCE_LATEST_JOB_DISCOVERY_INFO,
                 JOB_CLUSTER_INSTANCE_ACTION_UPDATE_ARTIFACT,
                 JOB_CLUSTER_INSTANCE_ACTION_UPDATE_SLA,
                 JOB_CLUSTER_INSTANCE_ACTION_UPDATE_MIGRATION_STRATEGY,

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobClustersRoute.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobClustersRoute.java
@@ -178,7 +178,7 @@ public class JobClustersRoute extends BaseRoute {
     }
 
     private Route getJobClustersRoute() {
-        logger.info("GET /api/v1/jobClusters called");
+        logger.debug("GET /api/v1/jobClusters called");
         return parameterMap(param -> extractUri(
 
                 uri -> completeAsync(

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
@@ -216,10 +216,10 @@ public class JobsRoute extends BaseRoute {
                        parameterMultiMap(params ->  extractUri (uri -> {
                             String endpoint;
                             if (clusterName.isPresent()) {
-                                logger.info("GET /api/v1/jobClusters/{}/jobs called", clusterName);
+                                logger.debug("GET /api/v1/jobClusters/{}/jobs called", clusterName);
                                 endpoint = HttpRequestMetrics.Endpoints.JOB_CLUSTER_INSTANCE_JOBS;
                             } else {
-                                logger.info("GET /api/v1/jobs called");
+                                logger.debug("GET /api/v1/jobs called");
                                 endpoint = HttpRequestMetrics.Endpoints.JOBS;
                             }
 

--- a/server/src/main/java/io/mantisrx/master/jobcluster/IJobClusterManager.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/IJobClusterManager.java
@@ -83,6 +83,8 @@ public interface IJobClusterManager {
 
     void onGetJobDetailsRequest(GetJobDetailsRequest req);
 
+    void onGetLatestJobDiscoveryInfo(JobClusterManagerProto.GetLatestJobDiscoveryInfoRequest request);
+
     void onGetJobStatusSubject(JobClusterManagerProto.GetJobSchedInfoRequest request);
 
     void onGetLastSubmittedJobIdSubject(JobClusterManagerProto.GetLastSubmittedJobIdStreamRequest request);

--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/IMantisJobManager.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/IMantisJobManager.java
@@ -51,6 +51,13 @@ public interface IMantisJobManager {
     void onGetJobStatusSubject(JobClusterManagerProto.GetJobSchedInfoRequest r);
 
     /**
+     * Process the discovery info request from a client by responding with
+     *
+     * @param r {@link JobClusterManagerProto.GetLatestJobDiscoveryInfoResponse} with latest discovery info for this job
+     */
+    void onGetLatestJobDiscoveryInfo(JobClusterManagerProto.GetLatestJobDiscoveryInfoRequest r);
+
+    /**
      * Process worker related events. Update worker state and transition worker to new states.
      *
      * @param e

--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -27,6 +27,7 @@ import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SERV
 import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SUCCESS;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -790,11 +791,11 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
             JobSchedulingInfo schedulingInfo = workerManager.getJobStatusSubject().getValue();
             if (schedulingInfo != null) {
                 sender.tell(new GetLatestJobDiscoveryInfoResponse(r.requestId, SUCCESS, "",
-                                                                  of(schedulingInfo)), getSelf());
+                                                                  ofNullable(schedulingInfo)), getSelf());
             } else {
                 LOGGER.info("discoveryInfo from BehaviorSubject is null {}", jobId);
                 sender.tell(new GetLatestJobDiscoveryInfoResponse(r.requestId, SERVER_ERROR, "discoveryInfo from BehaviorSubject is null " + jobId,
-                                                                  of(schedulingInfo)), getSelf());
+                                                                  empty()), getSelf());
             }
         } else {
             String msg = "JobCluster in the request " + r.getJobCluster() + " does not match Job Actors job ID " + this.jobId;

--- a/server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.jobcluster.proto;
 
+import akka.actor.ActorRef;
 import akka.http.javadsl.model.Uri;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -42,13 +43,10 @@ import io.mantisrx.server.master.domain.JobDefinition;
 import io.mantisrx.server.master.domain.JobId;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
 import rx.subjects.BehaviorSubject;
-import scala.Int;
 
 import java.time.Instant;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -1698,6 +1696,57 @@ public class JobClusterManagerProto {
         @Override
         public String toString() {
             return "GetJobDetailsResponse [jobMetadata=" + jobMetadata + "]";
+        }
+    }
+
+    public static final class GetLatestJobDiscoveryInfoRequest extends BaseRequest {
+
+        private final String jobCluster;
+
+        public GetLatestJobDiscoveryInfoRequest(final String jobCluster) {
+            Preconditions.checkNotNull(jobCluster, "jobCluster");
+            this.jobCluster = jobCluster;
+        }
+
+        public String getJobCluster() {
+            return jobCluster;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            GetLatestJobDiscoveryInfoRequest that = (GetLatestJobDiscoveryInfoRequest) o;
+            return Objects.equals(jobCluster, that.jobCluster);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(jobCluster);
+        }
+
+        @Override
+        public String toString() {
+            return "GetLatestJobDiscoveryInfoRequest{" +
+                "jobCluster='" + jobCluster + '\'' +
+                '}';
+        }
+    }
+
+    public static final class GetLatestJobDiscoveryInfoResponse extends BaseResponse {
+        private final Optional<JobSchedulingInfo> jobSchedulingInfo;
+
+        public GetLatestJobDiscoveryInfoResponse(
+            final long requestId,
+            final ResponseCode code,
+            final String msg,
+            final Optional<JobSchedulingInfo> jobSchedulingInfo) {
+            super(requestId, code, msg);
+            this.jobSchedulingInfo = jobSchedulingInfo;
+        }
+
+        public Optional<JobSchedulingInfo> getDiscoveryInfo() {
+            return jobSchedulingInfo;
         }
     }
 

--- a/server/src/main/java/io/mantisrx/server/master/LeadershipManagerLocalImpl.java
+++ b/server/src/main/java/io/mantisrx/server/master/LeadershipManagerLocalImpl.java
@@ -32,31 +32,37 @@ public class LeadershipManagerLocalImpl implements ILeadershipManager {
         this.masterDescription = masterDescription;
     }
 
+    @Override
     public void becomeLeader() {
         logger.info("Becoming leader now");
         isLeader = true;
     }
 
+    @Override
     public boolean isLeader() {
         logger.debug("is leader? {}", isLeader);
         return isLeader;
     }
 
+    @Override
     public boolean isReady() {
         return isReady;
     }
 
+    @Override
     public void setLeaderReady() {
         logger.info("marking leader READY");
         isReady = true;
     }
 
+    @Override
     public void stopBeingLeader() {
         logger.info("Asked to stop being leader now");
         isReady = false;
         isLeader = false;
     }
 
+    @Override
     public MasterDescription getDescription() {
         return masterDescription;
     }

--- a/server/src/main/java/io/mantisrx/server/master/persistence/SimpleCachedFileStorageProvider.java
+++ b/server/src/main/java/io/mantisrx/server/master/persistence/SimpleCachedFileStorageProvider.java
@@ -362,7 +362,7 @@ public class SimpleCachedFileStorageProvider implements IMantisStorageProvider {
     //
     private void storeWorker(JobId jobId, IMantisWorkerMetadata workerMetadata, boolean rewrite)
             throws IOException {
-        System.out.println("Storing worker " + workerMetadata);
+        logger.info("Storing worker {}", workerMetadata);
         File workerFile = new File(getWorkerFilename(SPOOL_DIR, jobId.getId(), workerMetadata.getWorkerIndex(), workerMetadata.getWorkerNumber()));
         if (rewrite)
             workerFile.delete();
@@ -370,7 +370,7 @@ public class SimpleCachedFileStorageProvider implements IMantisStorageProvider {
         try (PrintWriter pwrtr = new PrintWriter(workerFile)) {
             mapper.writeValue(pwrtr, workerMetadata);
         }
-        System.out.println("Stored worker " + workerMetadata);
+        logger.info("Stored worker {}", workerMetadata);
     }
 
     //

--- a/server/src/test/java/io/mantisrx/master/api/akka/MantisMasterAPI.java
+++ b/server/src/test/java/io/mantisrx/master/api/akka/MantisMasterAPI.java
@@ -233,7 +233,7 @@ public class MantisMasterAPI extends AllDirectives {
                 agentClusterOperations,
                 system);
 
-        final JobClustersRoute v1JobClustersRoute = new JobClustersRoute(jobClusterRouteHandler);
+        final JobClustersRoute v1JobClustersRoute = new JobClustersRoute(jobClusterRouteHandler, system);
         final JobsRoute v1JobsRoute = new JobsRoute(jobClusterRouteHandler, jobRouteHandler);
         final AdminMasterRoute v1AdminMasterRoute = new AdminMasterRoute(masterDescription);
         final AgentClustersRoute v1AgentClustersRoute = new AgentClustersRoute(agentClusterOperations);

--- a/server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobRouteTest.java
+++ b/server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobRouteTest.java
@@ -229,7 +229,7 @@ public class JobRouteTest {
                         jobRouteHandler,
                         system);
                 final JobClustersRoute v1JobClusterRoute = new JobClustersRoute(
-                        jobClusterRouteHandler);
+                        jobClusterRouteHandler, system);
                 final JobsRoute v1JobsRoute = new JobsRoute(
                         jobClusterRouteHandler,
                         jobRouteHandler);

--- a/server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobClustersRouteTest.java
+++ b/server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobClustersRouteTest.java
@@ -41,6 +41,7 @@ import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import org.omg.PortableInterceptor.NON_EXISTENT;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -53,6 +54,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -161,6 +163,22 @@ public class JobClustersRouteTest extends RouteTestBase {
                         JobClusterPayloads.JOB_CLUSTER_CREATE),
                 StatusCodes.CONFLICT,
                 null);
+    }
+
+    @Test(dependsOnMethods = {"testDuplicateJobClusterCreate"})
+    public void testNonExistentJobClusterLatestJobDiscoveryInfo() throws InterruptedException {
+        testGet(
+            getJobClusterLatestJobDiscoveryInfoEp("NonExistentCluster"),
+            StatusCodes.NOT_FOUND,
+            null);
+    }
+
+    @Test(dependsOnMethods = {"testDuplicateJobClusterCreate"})
+    public void testJobClusterLatestJobDiscoveryInfoNoRunningJobs() throws InterruptedException {
+        testGet(
+            getJobClusterLatestJobDiscoveryInfoEp(TEST_CLUSTER_NAME),
+            StatusCodes.NOT_FOUND,
+            null);
     }
 
     @Test(dependsOnMethods = "testDuplicateJobClusterCreate")

--- a/server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobClustersRouteTest.java
+++ b/server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobClustersRouteTest.java
@@ -41,6 +41,7 @@ import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import org.mockito.Mockito;
 import org.omg.PortableInterceptor.NON_EXISTENT;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +103,7 @@ public class JobClustersRouteTest extends RouteTestBase {
                 final JobClusterRouteHandler jobClusterRouteHandler = new JobClusterRouteHandlerAkkaImpl(
                         jobClustersManagerActor);
 
-                final JobClustersRoute app = new JobClustersRoute(jobClusterRouteHandler);
+                final JobClustersRoute app = new JobClustersRoute(jobClusterRouteHandler, system);
                 final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow =
                         app.createRoute(Function.identity())
                            .flow(system, materializer);

--- a/server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
+++ b/server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
@@ -162,7 +162,7 @@ public class JobsRouteTest extends RouteTestBase {
                         jobClusterRouteHandler,
                         jobRouteHandler);
                 final JobClustersRoute v1JobClusterRoute = new JobClustersRoute(
-                        jobClusterRouteHandler);
+                        jobClusterRouteHandler, system);
                 final AgentClustersRoute v1AgentClustersRoute = new AgentClustersRoute(
                         mockAgentClusterOps);
                 final JobStatusStreamRoute v1JobStatusStreamRoute = new JobStatusStreamRoute(


### PR DESCRIPTION
### Context
Add request-response style API to return latest Job's discovery info (a.k.a. schedulingInfo) given a job cluster. This optimizes the following interaction:

Mantis publish client polls the discovery info for a job cluster. This is accomplished by making 2 API calls: 1) get a stream of latest Job ID 2) Get a scheduling info stream for the latest job ID. The mantis api establishes long lived connections for both these API calls and eventually converts it to a HTTP response(non-streaming) back to mantis publish client. Adding this API for mantis API to avoid the unnecessary complexity and network round trips. 

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
