### PR TITLE
fix v1 job submit api response to return the same payload as GET resp…

### DIFF
--- a/server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
@@ -342,7 +342,7 @@ public class JobsRoute extends BaseRoute {
                             r,
                             resp -> complete(
                                     StatusCodes.CREATED,
-                                    resp.getJobMetadata().get(),
+                                    resp.getJobMetadata().map(metaData -> new MantisJobMetadataView(metaData, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false)),
                                     Jackson.marshaller()),
                             endpoint,
                             HttpRequestMetrics.HttpVerb.POST);
@@ -512,7 +512,7 @@ public class JobsRoute extends BaseRoute {
                             response,
                             resp -> complete(
                                     StatusCodes.CREATED,
-                                    resp.getJobMetadata().get(),
+                                    resp.getJobMetadata().map(metaData -> new MantisJobMetadataView(metaData, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false)),
                                     Jackson.marshaller()
                             ),
                             HttpRequestMetrics.Endpoints.JOBS_ACTION_QUICKSUBMIT,

--- a/server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
+++ b/server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
@@ -547,13 +547,14 @@ public class JobsRouteTest extends RouteTestBase {
             assert !Strings.isNullOrEmpty(resp);
             ObjectMapper mapper = new ObjectMapper();
             JsonNode responseObj = mapper.readTree(resp);
-            assert responseObj.get("jobId").get("cluster").asText().equals(TEST_CLUSTER);
-            assert responseObj.get("jobId").get("id").asText().startsWith("sine-function-");
+            assert responseObj.get("jobMetadata").get("name").asText().equals(TEST_CLUSTER);
+            assert responseObj.get("jobMetadata").get("jobId").asText().startsWith("sine-function-");
+            assert responseObj.get("jobMetadata").get("sla") != null;
+            assert responseObj.get("jobMetadata").get("labels") != null;
 
-            validateJobDefinition(responseObj.get("jobDefinition"));
+            assert responseObj.get("stageMetadataList") != null;
+            assert responseObj.get("workerMetadataList") != null;
 
-            assert responseObj.get("parameters").size() == 2;
-            assert responseObj.get("clusterName").asText().equals(TEST_CLUSTER);
         } catch (IOException ex) {
             logger.error("Failed to validate job response: " + ex.getMessage());
             assert false;


### PR DESCRIPTION
…onse

### Context

This PR contains a bug fix where the v1 API job submission (both regular and quick submit) response payload json structure is different from the GET response.

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [N/A] Extended README or added javadocs where applicable
- [N/A] Added copyright headers for new files from `CONTRIBUTING.md`
