### PR TITLE
Caching in Mantis Master API v1 for listing jobs.

### DIFF
--- a/server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
@@ -156,7 +156,7 @@ public class MasterApiAkkaService extends BaseService {
         final JobStatusRoute v0JobStatusRoute = new JobStatusRoute(jobStatusRouteHandler);
 
         final JobClustersRoute v1JobClusterRoute = new JobClustersRoute(jobClusterRouteHandler, actorSystem);
-        final JobsRoute v1JobsRoute = new JobsRoute(jobClusterRouteHandler, jobRouteHandler);
+        final JobsRoute v1JobsRoute = new JobsRoute(jobClusterRouteHandler, jobRouteHandler, actorSystem);
         final AdminMasterRoute v1AdminMasterRoute = new AdminMasterRoute(masterDescription);
         final AgentClustersRoute v1AgentClustersRoute = new AgentClustersRoute(agentClusterOperations);
         final JobDiscoveryStreamRoute v1JobDiscoveryStreamRoute = new JobDiscoveryStreamRoute(jobDiscoveryRouteHandler);

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/v0/AgentClusterRoute.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/v0/AgentClusterRoute.java
@@ -38,6 +38,8 @@ import io.mantisrx.common.metrics.Counter;
 import io.mantisrx.common.metrics.Metrics;
 import io.mantisrx.master.api.akka.route.Jackson;
 import io.mantisrx.master.vm.AgentClusterOperations;
+import io.mantisrx.server.master.config.ConfigurationProvider;
+import io.mantisrx.server.master.config.MasterConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +77,9 @@ public class AgentClusterRoute extends BaseRoute {
     public AgentClusterRoute(final AgentClusterOperations agentClusterOperations, final ActorSystem actorSystem) {
         Preconditions.checkNotNull(agentClusterOperations, "agentClusterOperations");
         this.agentClusterOps = agentClusterOperations;
-        this.cache = routeCache(CachingSettings.create(actorSystem));
+        MasterConfiguration config = ConfigurationProvider.getConfig();
+        this.cache = createCache(actorSystem, config.getApiCacheMinSize(), config.getApiCacheMaxSize(),
+                config.getApiCacheTtlMilliseconds());
 
         Metrics m = new Metrics.Builder()
             .id("V0AgentClusterRoute")

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/v0/JobClusterRoute.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/v0/JobClusterRoute.java
@@ -52,6 +52,7 @@ import io.mantisrx.runtime.descriptor.SchedulingInfo;
 import io.mantisrx.runtime.descriptor.StageScalingPolicy;
 import io.mantisrx.runtime.descriptor.StageSchedulingInfo;
 import io.mantisrx.server.master.config.ConfigurationProvider;
+import io.mantisrx.server.master.config.MasterConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.concurrent.duration.Duration;
@@ -132,7 +133,9 @@ public class JobClusterRoute extends BaseRoute {
                              final ActorSystem actorSystem) {
         this.jobClusterRouteHandler = jobClusterRouteHandler;
         this.jobRouteHandler = jobRouteHandler;
-        this.cache = createCache(actorSystem);
+        MasterConfiguration config = ConfigurationProvider.getConfig();
+        this.cache = createCache(actorSystem, config.getApiCacheMinSize(), config.getApiCacheMaxSize(),
+                config.getApiCacheTtlMilliseconds());
 
         Metrics m = new Metrics.Builder()
                 .id("V0JobClusterRoute")

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/v0/JobRoute.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/v0/JobRoute.java
@@ -49,6 +49,7 @@ import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.ResubmitWorker
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.ScaleStageRequest;
 import io.mantisrx.server.core.PostJobStatusRequest;
 import io.mantisrx.server.master.config.ConfigurationProvider;
+import io.mantisrx.server.master.config.MasterConfiguration;
 import io.mantisrx.server.master.domain.DataFormatAdapter;
 import io.mantisrx.server.master.domain.JobId;
 import io.mantisrx.server.master.scheduler.WorkerEvent;
@@ -100,7 +101,9 @@ public class JobRoute extends BaseRoute {
 
     public JobRoute(final JobRouteHandler jobRouteHandler, final ActorSystem actorSystem) {
         this.jobRouteHandler = jobRouteHandler;
-        this.cache = routeCache(CachingSettings.create(actorSystem));
+        MasterConfiguration config = ConfigurationProvider.getConfig();
+        this.cache = createCache(actorSystem, config.getApiCacheMinSize(), config.getApiCacheMaxSize(),
+                config.getApiCacheTtlMilliseconds());
 
         Metrics m = new Metrics.Builder()
             .id("V0JobRoute")

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobClustersRoute.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobClustersRoute.java
@@ -33,6 +33,8 @@ import io.mantisrx.master.api.akka.route.proto.JobClusterProtoAdapter;
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.runtime.NamedJobDefinition;
+import io.mantisrx.server.master.config.ConfigurationProvider;
+import io.mantisrx.server.master.config.MasterConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,11 +70,12 @@ public class JobClustersRoute extends BaseRoute {
     private final JobClusterRouteHandler jobClusterRouteHandler;
     private final Cache<Uri, RouteResult> routeResultCache;
 
-
     public JobClustersRoute(final JobClusterRouteHandler jobClusterRouteHandler,
                             final ActorSystem actorSystem) {
         this.jobClusterRouteHandler = jobClusterRouteHandler;
-        this.routeResultCache = createCache(actorSystem, 5, 50, 250);
+        MasterConfiguration config = ConfigurationProvider.getConfig();
+        this.routeResultCache = createCache(actorSystem, config.getApiCacheMinSize(), config.getApiCacheMaxSize(),
+                config.getApiCacheTtlMilliseconds());
     }
 
     public Route constructRoutes() {

--- a/server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
@@ -16,16 +16,14 @@
 
 package io.mantisrx.master.api.akka.route.v1;
 
+import akka.actor.ActorSystem;
+import akka.http.caching.javadsl.Cache;
 import akka.http.javadsl.model.StatusCodes;
-import akka.http.javadsl.server.PathMatcher0;
-import akka.http.javadsl.server.PathMatcher1;
-import akka.http.javadsl.server.PathMatchers;
-import akka.http.javadsl.server.Route;
+import akka.http.javadsl.model.Uri;
+import akka.http.javadsl.server.*;
 import akka.http.javadsl.unmarshalling.StringUnmarshallers;
 import akka.japi.Pair;
 import com.google.common.base.Strings;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import io.mantisrx.master.api.akka.route.Jackson;
 import io.mantisrx.master.api.akka.route.handlers.JobClusterRouteHandler;
 import io.mantisrx.master.api.akka.route.handlers.JobRouteHandler;
@@ -53,13 +51,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static akka.http.javadsl.server.PathMatchers.segment;
 import static io.mantisrx.master.api.akka.route.utils.JobRouteUtils.createListJobsRequest;
 import static io.mantisrx.master.api.akka.route.utils.JobRouteUtils.createWorkerStatusRequest;
 import static io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.ListArchivedWorkersRequest.DEFAULT_LIST_ARCHIVED_WORKERS_LIMIT;
+import static akka.http.javadsl.server.directives.CachingDirectives.cache;
+import static akka.http.javadsl.server.directives.CachingDirectives.alwaysCache;
 
 /***
  * JobsRoute
@@ -87,21 +86,16 @@ public class JobsRoute extends BaseRoute {
     private final JobRouteHandler jobRouteHandler;
     private final JobClusterRouteHandler clusterRouteHandler;
     private final MasterConfiguration config;
-
-    private final Cache<JobClusterManagerProto.ListJobsRequest, JobClusterManagerProto.ListJobsResponse> listJobsCache;
+    private final Cache<Uri, RouteResult> routeResultCache;
 
     public JobsRoute(
             final JobClusterRouteHandler clusterRouteHandler,
-            final JobRouteHandler jobRouteHandler) {
+            final JobRouteHandler jobRouteHandler,
+            final ActorSystem actorSystem) {
         this.jobRouteHandler = jobRouteHandler;
         this.clusterRouteHandler = clusterRouteHandler;
-
-        config = ConfigurationProvider.getConfig();
-        listJobsCache = CacheBuilder
-                .newBuilder()
-                .maximumSize(config.getApiCacheMaxSize())
-                .expireAfterAccess(config.getApiCacheExpirySeconds(), TimeUnit.SECONDS)
-                .build();
+        this.config = ConfigurationProvider.getConfig();
+        this.routeResultCache = createCache(actorSystem, config.getApiCacheMinSize(), config.getApiCacheMaxSize(), config.getApiCacheTtlMilliseconds());
     }
 
 
@@ -227,7 +221,8 @@ public class JobsRoute extends BaseRoute {
                     parameterOptional(StringUnmarshallers.STRING, ParamName.PROJECTION_TARGET, (target) ->
                      parameterOptional(StringUnmarshallers.BOOLEAN, ParamName.JOB_COMPACT, (isCompact) ->
                       parameterOptional(StringUnmarshallers.STRING, ParamName.JOB_FILTER_MATCH, (matching) ->
-                       parameterMultiMap(params ->  extractUri (uri -> {
+                       parameterMultiMap(params ->
+                               alwaysCache(routeResultCache, getRequestUriKeyer , () -> extractUri(uri -> {
                             String endpoint;
                             if (clusterName.isPresent()) {
                                 logger.debug("GET /api/v1/jobClusters/{}/jobs called", clusterName);
@@ -242,17 +237,10 @@ public class JobsRoute extends BaseRoute {
                                     clusterName.map(s -> Optional.of("^" + s + "$")).orElse(matching),
                                     true);
 
-                              JobClusterManagerProto.ListJobsResponse cachedResponse = listJobsCache.getIfPresent(listJobsRequest);
 
                               return completeAsync(
-                                    cachedResponse == null ? jobRouteHandler.listJobs(listJobsRequest) : CompletableFuture.completedFuture(cachedResponse),
-                                    resp -> {
-
-                                        if (config.getApiCacheEnabled() && cachedResponse == null) {
-                                            listJobsCache.put(listJobsRequest, resp);
-                                        }
-
-                                        return completeOK(
+                                    jobRouteHandler.listJobs(listJobsRequest),
+                                    resp -> completeOK(
                                             (isCompact.isPresent() && isCompact.get()) ?
                                                     resp.getJobList(
                                                             JobClusterProtoAdapter::toCompactJobInfo,
@@ -270,12 +258,11 @@ public class JobsRoute extends BaseRoute {
                                             Jackson.marshaller(
                                                     super.parseFilter(fields.orElse(null),
                                                             target.orElse(null)))
-                                    );
-                                        },
+                                    ),
                                     endpoint,
                                     HttpRequestMetrics.HttpVerb.GET
                             );
-                        }))))))))));
+                        })))))))))));
 
     }
 

--- a/server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -283,15 +283,15 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("100.0")
     double getJobMasterDiskMB();
 
-    @Config("mantis.master.api.cache.expiry.seconds")
-    @Default("1")
-    long getApiCacheExpirySeconds();
+    @Config("mantis.master.api.cache.ttl.milliseconds")
+    @Default("250")
+    int getApiCacheTtlMilliseconds();
 
     @Config("mantis.master.api.cache.size.max")
-    @Default("100")
-    long getApiCacheMaxSize();
+    @Default("50")
+    int getApiCacheMaxSize();
 
-    @Config("mantis.master.api.cache.enabled")
-    @Default("false")
-    boolean getApiCacheEnabled();
+    @Config("mantis.master.api.cache.size.min")
+    @Default("5")
+    int getApiCacheMinSize();
 }

--- a/server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -282,4 +282,16 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Config("mantis.job.master.scheduling.info.diskMB")
     @Default("100.0")
     double getJobMasterDiskMB();
+
+    @Config("mantis.master.api.cache.expiry.seconds")
+    @Default("1")
+    long getApiCacheExpirySeconds();
+
+    @Config("mantis.master.api.cache.size.max")
+    @Default("100")
+    long getApiCacheMaxSize();
+
+    @Config("mantis.master.api.cache.enabled")
+    @Default("false")
+    boolean getApiCacheEnabled();
 }

--- a/server/src/test/java/io/mantisrx/master/api/akka/MantisMasterAPI.java
+++ b/server/src/test/java/io/mantisrx/master/api/akka/MantisMasterAPI.java
@@ -234,7 +234,7 @@ public class MantisMasterAPI extends AllDirectives {
                 system);
 
         final JobClustersRoute v1JobClustersRoute = new JobClustersRoute(jobClusterRouteHandler, system);
-        final JobsRoute v1JobsRoute = new JobsRoute(jobClusterRouteHandler, jobRouteHandler);
+        final JobsRoute v1JobsRoute = new JobsRoute(jobClusterRouteHandler, jobRouteHandler, system);
         final AdminMasterRoute v1AdminMasterRoute = new AdminMasterRoute(masterDescription);
         final AgentClustersRoute v1AgentClustersRoute = new AgentClustersRoute(agentClusterOperations);
         final JobDiscoveryStreamRoute v1JobDiscoveryStreamRoute = new JobDiscoveryStreamRoute(jobDiscoveryRouteHandler);

--- a/server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobRouteTest.java
+++ b/server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobRouteTest.java
@@ -232,7 +232,8 @@ public class JobRouteTest {
                         jobClusterRouteHandler, system);
                 final JobsRoute v1JobsRoute = new JobsRoute(
                         jobClusterRouteHandler,
-                        jobRouteHandler);
+                        jobRouteHandler,
+                        system);
                 final AdminMasterRoute v1AdminMasterRoute = new AdminMasterRoute(masterDescription);
 
                 final JobStatusRouteHandler jobStatusRouteHandler = mock(JobStatusRouteHandler.class);

--- a/server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
+++ b/server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
@@ -160,7 +160,8 @@ public class JobsRouteTest extends RouteTestBase {
 
                 final JobsRoute v1JobsRoute = new JobsRoute(
                         jobClusterRouteHandler,
-                        jobRouteHandler);
+                        jobRouteHandler,
+                        system);
                 final JobClustersRoute v1JobClusterRoute = new JobClustersRoute(
                         jobClusterRouteHandler, system);
                 final AgentClustersRoute v1AgentClustersRoute = new AgentClustersRoute(


### PR DESCRIPTION
### Context
The jobs list call is expensive having to reach out to all actors in the system and wait for a response. Some short term caching as discussed in the team meeting will greatly reduce the frequency with which the API needs to wait for a response from all actors.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
