### PR TITLE
Add resiliency around missing scheduling info.

### DIFF
--- a/server/src/main/java/io/mantisrx/master/jobcluster/WorkerInfoListHolder.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/WorkerInfoListHolder.java
@@ -16,10 +16,10 @@
 
 package io.mantisrx.master.jobcluster;
 
+import java.util.List;
+
 import io.mantisrx.master.jobcluster.job.worker.IMantisWorkerMetadata;
 import io.mantisrx.server.master.domain.JobId;
-
-import java.util.List;
 
 public class WorkerInfoListHolder {
 
@@ -37,5 +37,13 @@ public class WorkerInfoListHolder {
 
     public List<IMantisWorkerMetadata> getWorkerMetadataList() {
         return workerMetadataList;
+    }
+
+    @Override
+    public String toString() {
+        return "WorkerInfoListHolder{"
+                + " jobId=" + jobId
+                + ", workerMetadataList=" + workerMetadataList
+                + '}';
     }
 }

--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/MantisStageMetadataImpl.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/MantisStageMetadataImpl.java
@@ -565,7 +565,6 @@ public class MantisStageMetadataImpl implements IMantisStageMetadata {
      */
     public Optional<JobWorker> processWorkerEvent(WorkerEvent event, MantisJobStore jobStore) {
         try {
-
             JobWorker worker = getWorkerByIndex(event.getWorkerId().getWorkerIndex());
             worker.processEvent(event, jobStore);
             return of(worker);

--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/worker/IMantisWorkerMetadata.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/worker/IMantisWorkerMetadata.java
@@ -16,17 +16,16 @@
 
 package io.mantisrx.master.jobcluster.job.worker;
 
+import java.time.Instant;
+import java.util.Optional;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.server.core.JobCompletedReason;
 import io.mantisrx.server.core.domain.WorkerId;
-
 import io.mantisrx.server.master.domain.JobId;
-
-import java.time.Instant;
-import java.util.Optional;
 
 /**
  * Metadata object for a Mantis worker. Modification operations do not perform locking. Instead, a lock can be
@@ -79,6 +78,11 @@ public interface IMantisWorkerMetadata {
     int getStageNum();
 
     /**
+     * @return the {@link WorkerPorts} for this worker.
+     */
+    WorkerPorts getWorkerPorts();
+
+    /**
      * The port on which Metrics stream is served.
      * @return
      */
@@ -101,6 +105,13 @@ public interface IMantisWorkerMetadata {
      * @return
      */
     int getCustomPort();
+
+    /**
+     * The port which can be used to connect to other workers.
+     *
+     * @return
+     */
+    int getSinkPort();
 
 
     /**

--- a/server/src/main/java/io/mantisrx/master/jobcluster/job/worker/MantisWorkerMetadataImpl.java
+++ b/server/src/main/java/io/mantisrx/master/jobcluster/job/worker/MantisWorkerMetadataImpl.java
@@ -16,25 +16,22 @@
 
 package io.mantisrx.master.jobcluster.job.worker;
 
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.mantisrx.common.WorkerPorts;
-
-
 import io.mantisrx.server.core.JobCompletedReason;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.domain.JobId;
-
 import io.mantisrx.server.master.persistence.exceptions.InvalidWorkerStateChangeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.time.Instant;
-import java.util.Objects;
-import java.util.Optional;
 
 
 /**
@@ -211,6 +208,10 @@ public class MantisWorkerMetadataImpl implements IMantisWorkerMetadata {
     }
     public int getCustomPort() {
         return workerPorts == null ? -1 : workerPorts.getCustomPort();
+    }
+
+    public int getSinkPort() {
+        return workerPorts == null ? -1 : workerPorts.getSinkPort();
     }
 
     public int getResubmitOf() {

--- a/server/src/main/java/io/mantisrx/server/master/mesos/VirtualMachineMasterServiceMesosImpl.java
+++ b/server/src/main/java/io/mantisrx/server/master/mesos/VirtualMachineMasterServiceMesosImpl.java
@@ -93,7 +93,7 @@ public class VirtualMachineMasterServiceMesosImpl extends BaseService implements
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
-    // NOTE: all leases are for the same slave
+    // NOTE: All leases are for the same agent.
     @Override
     public Map<ScheduleRequest, LaunchTaskException> launchTasks(List<LaunchTaskRequest> requests, List<VirtualMachineLease> leases) {
         if (!super.getIsInited()) {

--- a/server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestHelper.java
+++ b/server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestHelper.java
@@ -16,6 +16,16 @@
 
 package io.mantisrx.master.jobcluster.job;
 
+import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.testkit.javadsl.TestKit;
@@ -43,7 +53,6 @@ import io.mantisrx.server.core.JobCompletedReason;
 import io.mantisrx.server.core.Status;
 import io.mantisrx.server.core.Status.TYPE;
 import io.mantisrx.server.core.domain.WorkerId;
-
 import io.mantisrx.server.master.domain.IJobClusterDefinition;
 import io.mantisrx.server.master.domain.JobClusterConfig;
 import io.mantisrx.server.master.domain.JobClusterDefinitionImpl;
@@ -54,17 +63,6 @@ import io.mantisrx.server.master.scheduler.MantisScheduler;
 import io.mantisrx.server.master.scheduler.WorkerEvent;
 import io.mantisrx.server.master.scheduler.WorkerLaunched;
 import org.junit.Test;
-import rx.Observable;
-
-import java.io.File;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Optional;
-
-import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SUCCESS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 public class JobTestHelper {
@@ -225,8 +223,13 @@ public class JobTestHelper {
         jobActor.tell(startedEvent, probe.getRef());
     }
 
+    public static void sendJobInitializeEvent(final TestKit probe, final ActorRef jobClusterActor) {
+        JobProto.InitJob initJobEvent = new JobProto.InitJob(probe.getRef(), true);
+        jobClusterActor.tell(initJobEvent, probe.getRef());
+    }
+
     public static void sendWorkerLaunchedEvent(final TestKit probe, final ActorRef jobActor, WorkerId workerId2, int stageNo) {
-        WorkerEvent launchedEvent2 = new WorkerLaunched(workerId2, stageNo, "host1", "vm1", Optional.empty(), new WorkerPorts(8000, 9000, 9010, 9011, Lists.newArrayList(9020)));
+        WorkerEvent launchedEvent2 = new WorkerLaunched(workerId2, stageNo, "host1", "vm1", Optional.empty(), new WorkerPorts(Lists.newArrayList(8000, 9000, 9010, 9020, 9030)));
         jobActor.tell(launchedEvent2, probe.getRef());
     }
 
@@ -385,21 +388,4 @@ public class JobTestHelper {
         assertEquals(1, JobHelper.calculateRuntimeDuration(10, startedAt));
 
     }
-
-
-    public static void main(String[] args) {
-
-        Observable.range(0, 100)
-            .groupBy((i) -> i % 2)
-            .flatMap((go) -> go
-                .buffer(2)
-                .map((lst) -> String.valueOf(lst)))
-            .toBlocking()
-            .subscribe((res) -> {
-                System.out.println("res -> " + res);
-            });
-
-    }
-
-
 }

--- a/server/src/test/java/io/mantisrx/master/scheduler/FakeMantisScheduler.java
+++ b/server/src/test/java/io/mantisrx/master/scheduler/FakeMantisScheduler.java
@@ -16,6 +16,10 @@
 
 package io.mantisrx.master.scheduler;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 import akka.actor.ActorRef;
 import com.google.common.collect.Lists;
 import com.netflix.fenzo.VirtualMachineCurrentState;
@@ -26,16 +30,11 @@ import io.mantisrx.master.jobcluster.job.worker.WorkerStatus;
 import io.mantisrx.runtime.MantisJobState;
 import io.mantisrx.server.core.Status;
 import io.mantisrx.server.core.domain.WorkerId;
-
 import io.mantisrx.server.master.scheduler.MantisScheduler;
 import io.mantisrx.server.master.scheduler.ScheduleRequest;
 import io.mantisrx.server.master.scheduler.WorkerEvent;
 import io.mantisrx.server.master.scheduler.WorkerLaunched;
 import io.mantisrx.server.master.scheduler.WorkerResourceStatus;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 public class FakeMantisScheduler implements MantisScheduler {
 
@@ -52,7 +51,7 @@ public class FakeMantisScheduler implements MantisScheduler {
             scheduleRequest.getStageNum(),
             "host1",
             "vm1",
-            scheduleRequest.getPreferredCluster(), new WorkerPorts(8000, 9000, 9010, 9020, Lists.newArrayList(9030)));
+            scheduleRequest.getPreferredCluster(), new WorkerPorts(Lists.newArrayList(8000, 9000, 9010, 9020, 9030)));
 
         jobClusterManagerActor.tell(workerLaunched, ActorRef.noSender());
 

--- a/server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
+++ b/server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
@@ -16,12 +16,22 @@
 
 package io.mantisrx.server.master.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import static java.util.Optional.of;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.Lists;
 import io.mantisrx.common.Label;
@@ -54,28 +64,11 @@ import io.mantisrx.runtime.descriptor.SchedulingInfo;
 import io.mantisrx.runtime.descriptor.StageScalingPolicy;
 import io.mantisrx.runtime.parameter.Parameter;
 import io.mantisrx.server.core.JobCompletedReason;
-
 import io.mantisrx.server.master.store.MantisJobMetadata;
 import io.mantisrx.server.master.store.MantisStageMetadataWritable;
 import io.mantisrx.server.master.store.MantisWorkerMetadataWritable;
 import io.mantisrx.server.master.store.NamedJob;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static java.util.Optional.of;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class DataFormatAdapterTest {
     public static final MachineDefinition DEFAULT_MACHINE_DEFINITION = new MachineDefinition(1, 10, 10, 10, 2);
@@ -343,6 +336,7 @@ public class DataFormatAdapterTest {
             "  \"metricsPort\": 1,\n" +
             "  \"consolePort\": 3,\n" +
             "  \"debugPort\": 2,\n" +
+            "  \"customPort\": 5,\n" +
             "  \"ports\": [4],\n" +
             "  \"state\": \"Completed\",\n" +
             "  \"slave\": \"slave1\",\n" +
@@ -364,7 +358,7 @@ public class DataFormatAdapterTest {
         int metricsPort = 1;
         int debugPort = 2;
         int consolePort = 3;
-        int customPort = 0;
+        int customPort = 5;
         int ssePort = 4;
         List<Integer> ports = Lists.newArrayList();
 
@@ -432,7 +426,7 @@ public class DataFormatAdapterTest {
         assertEquals(metricsPort, oldMetadataWritable.getMetricsPort());
         assertEquals(consolePort, oldMetadataWritable.getConsolePort());
         assertEquals(debugPort, oldMetadataWritable.getDebugPort());
-        assertEquals(0, oldMetadataWritable.getCustomPort());
+        assertEquals(5, oldMetadataWritable.getCustomPort());
 
         assertEquals(MantisJobState.Completed, oldMetadataWritable.getState());
 
@@ -635,7 +629,7 @@ public class DataFormatAdapterTest {
                                                                         .build();
         IMantisWorkerMetadata workerMetadata = new MantisWorkerMetadataImpl(0,
                 1, jobId.getId(),
-                1,3, new WorkerPorts(100,200,300, 400, Collections.singletonList(500)), WorkerState.Started,
+                1,3, new WorkerPorts(Lists.newArrayList(8000, 9000, 9010, 9020, 9030)), WorkerState.Started,
                 "slave","slaveId",startedAt.toEpochMilli(),startedAt.toEpochMilli(),
                 startedAt.toEpochMilli(),startedAt.toEpochMilli(),-1,JobCompletedReason.Normal,
                 0,0,of("cluster"));


### PR DESCRIPTION
### Context

This commit uses work from Netflix/mantis#37 to
address edge cases for missing scheduling info.

We catch the following cases:

1. On Mantis Master failover.
  - There are probably existing running workers but since it's a
newly-elected leader, it needs to update its view of the world. If Mesos
doesn't send it legit worker information, **mark them for resubmission and
resubmit them in bulk at the end of initialization**.
  - If it fails to load worker info from persistence due to corruption,
**proactively resubmit the worker**.
2. On a fresh job submit.
  - Master will notice that the worker doesn't have the correct
information. **Proactively unschedule the worker for the assignment
result**.

This commit also adds one metric:

1. `numMissingWorkerPorts` which measures the number of workers
with missing ports, specifically on master failover.

Lastly, this commit does some minor refactoring:

1. Some helper methods.
2. Javadocs clarity.
3. **Fix broken tests due to tighter validation around `WorkerPorts`**.
  - Also makes sure our tests use the same `WorkerPorts` constructor signature
as the real service.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
