### PR TITLE
Remove akka dependencies from core module

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -25,14 +25,12 @@ ext {
     jsonVersion = '20180813'
     mantisVersion = '1.2.+'
     mesosVersion = '1.3.2'
-    rxJavaReactiveStreamsVersion = '1.+'
     testngVersion = '6.14.+'
 }
 
 dependencies {
 
     api "io.mantisrx:mantis-common:$mantisVersion"
-    api "io.reactivex:rxjava-reactive-streams:$rxJavaReactiveStreamsVersion"
 
     api "org.skife.config:config-magic:$configMagicVersion"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     api "org.apache.curator:curator-recipes:$curatorVersion"
     api "joda-time:joda-time:$jodaTimeVersion"
 
-    testCompile "com.typesafe.akka:akka-testkit_2.13:$akkaVersion"
+
     testCompile "junit:junit:4.+"
     testCompile "org.mockito:mockito-all:2.+"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,12 +15,10 @@
  */
 
 ext {
-    akkaHttpVersion = '10.1.8'
-    akkaVersion = '2.5.23'
+
     cliParserVersion = '1.1.1'
     configMagicVersion = '0.11'
     curatorVersion = '2.11.0'
-    fenzoVersion = '0.13.8'
     guavaVersion = '19.0'
     hdrHistogramVersion = '2.+'
     jodaTimeVersion = '2.+'
@@ -32,13 +30,9 @@ ext {
 }
 
 dependencies {
-    // Master API akka-http dependencies
 
     api "io.mantisrx:mantis-common:$mantisVersion"
     api "io.reactivex:rxjava-reactive-streams:$rxJavaReactiveStreamsVersion"
-
-    api "com.netflix.fenzo:fenzo-core:$fenzoVersion"
-    api "com.netflix.fenzo:fenzo-triggers:$fenzoVersion"
 
     api "org.skife.config:config-magic:$configMagicVersion"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -33,15 +33,7 @@ ext {
 
 dependencies {
     // Master API akka-http dependencies
-    api "com.typesafe.akka:akka-http_2.13:$akkaHttpVersion"
-    api "com.typesafe.akka:akka-http-jackson_2.13:$akkaHttpVersion"
-    api "com.typesafe.akka:akka-http-caching_2.13:$akkaHttpVersion"
-    api "com.typesafe.akka:akka-stream_2.13:$akkaVersion"
-    compile group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '2.5.23'
-    api "com.typesafe.akka:akka-slf4j_2.13:$akkaVersion"
 
-    // Master core
-    api "com.typesafe.akka:akka-actor_2.13:$akkaVersion"
     api "io.mantisrx:mantis-common:$mantisVersion"
     api "io.reactivex:rxjava-reactive-streams:$rxJavaReactiveStreamsVersion"
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'application'
 ext {
     akkaVersion = '2.5.23'
     akkaHttpVersion = '10.1.8'
-
+    fenzoVersion = '0.13.8'
     cliParserVersion = '1.1.1'
     configMagicVersion = '0.11'
     curatorVersion = '2.11.0'
@@ -37,8 +37,9 @@ dependencies {
     compile group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '2.5.23'
     api "com.typesafe.akka:akka-slf4j_2.13:$akkaVersion"
 
-
     api "com.typesafe.akka:akka-actor_2.13:$akkaVersion"
+    api "com.netflix.fenzo:fenzo-core:$fenzoVersion"
+    api "com.netflix.fenzo:fenzo-triggers:$fenzoVersion"
     api "com.github.spullara.cli-parser:cli-parser:$cliParserVersion"
     api "com.google.guava:guava:$guavaVersion"
     api "org.apache.curator:curator-framework:$curatorVersion"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -22,6 +22,7 @@ ext {
     fenzoVersion = '0.13.8'
     cliParserVersion = '1.1.1'
     configMagicVersion = '0.11'
+    rxJavaReactiveStreamsVersion = '1.+'
     curatorVersion = '2.11.0'
     guavaVersion = '19.0'
     testngVersion = '6.+'
@@ -38,6 +39,7 @@ dependencies {
     api "com.typesafe.akka:akka-slf4j_2.13:$akkaVersion"
 
     api "com.typesafe.akka:akka-actor_2.13:$akkaVersion"
+    api "io.reactivex:rxjava-reactive-streams:$rxJavaReactiveStreamsVersion"
     api "com.netflix.fenzo:fenzo-core:$fenzoVersion"
     api "com.netflix.fenzo:fenzo-triggers:$fenzoVersion"
     api "com.github.spullara.cli-parser:cli-parser:$cliParserVersion"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -18,6 +18,8 @@ apply plugin: 'application'
 
 ext {
     akkaVersion = '2.5.23'
+    akkaHttpVersion = '10.1.8'
+
     cliParserVersion = '1.1.1'
     configMagicVersion = '0.11'
     curatorVersion = '2.11.0'
@@ -28,6 +30,15 @@ ext {
 dependencies {
     compile project(':mantis-control-plane-core')
 
+    api "com.typesafe.akka:akka-http_2.13:$akkaHttpVersion"
+    api "com.typesafe.akka:akka-http-jackson_2.13:$akkaHttpVersion"
+    api "com.typesafe.akka:akka-http-caching_2.13:$akkaHttpVersion"
+    api "com.typesafe.akka:akka-stream_2.13:$akkaVersion"
+    compile group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '2.5.23'
+    api "com.typesafe.akka:akka-slf4j_2.13:$akkaVersion"
+
+    // Master core
+    api "com.typesafe.akka:akka-actor_2.13:$akkaVersion"
     api "com.github.spullara.cli-parser:cli-parser:$cliParserVersion"
     api "com.google.guava:guava:$guavaVersion"
     api "org.apache.curator:curator-framework:$curatorVersion"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '2.5.23'
     api "com.typesafe.akka:akka-slf4j_2.13:$akkaVersion"
 
-    // Master core
+
     api "com.typesafe.akka:akka-actor_2.13:$akkaVersion"
     api "com.github.spullara.cli-parser:cli-parser:$cliParserVersion"
     api "com.google.guava:guava:$guavaVersion"


### PR DESCRIPTION
### Context
Mantis Jobs inadvertently pull in akka dependencies due to the nfmantis-runtime depending on mantis-control-plane-core (which has these dependencies)
This PR moves these dependencies to the server module


### Checklist

- [ x] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
