### PR TITLE
Upgrade Mesos lib from 1.4.2 to 1.7.2

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,7 +24,7 @@ ext {
     jodaTimeVersion = '2.+'
     jsonVersion = '20180813'
     mantisVersion = '1.2.+'
-    mesosVersion = '1.4.2'
+    mesosVersion = '1.7.2'
     testngVersion = '6.14.+'
 }
 

--- a/server/src/main/java/io/mantisrx/server/master/domain/DataFormatAdapter.java
+++ b/server/src/main/java/io/mantisrx/server/master/domain/DataFormatAdapter.java
@@ -350,7 +350,7 @@ public class DataFormatAdapter {
         try {
             workerPorts = new WorkerPorts(ports);
         } catch (IllegalArgumentException | IllegalStateException e) {
-            logger.debug("problem loading worker {} for Job ID {}", writeable.getWorkerId(), jobId, e);
+            logger.warn("problem loading worker {} for Job ID {}", writeable.getWorkerId(), jobId, e);
         }
 
         JobWorker converted = new JobWorker.Builder()


### PR DESCRIPTION
### Context

Upgrade Mesos lib version from 1.4.2 to 1.7.2. Tested and rolled out internally, moving into open source.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
