### PR TITLE
Reduce noise on Mesos reconciliation.

### DIFF
--- a/server/src/main/java/io/mantisrx/server/master/mesos/MesosSchedulerCallbackHandler.java
+++ b/server/src/main/java/io/mantisrx/server/master/mesos/MesosSchedulerCallbackHandler.java
@@ -332,7 +332,7 @@ public class MesosSchedulerCallbackHandler implements Scheduler {
     @Override
     public void statusUpdate(final SchedulerDriver arg0, TaskStatus arg1) {
         Optional<WorkerId> workerIdO = WorkerId.fromId(arg1.getTaskId().getValue());
-        logger.info("Task status update: ({}) state: {}({}) - {}",
+        logger.debug("Task status update: ({}) state: {}({}) - {}",
                 arg1.getTaskId().getValue(),
                 arg1.getState(),
                 arg1.getState().getNumber(),


### PR DESCRIPTION
### Context

This log line has negative performance impact at scale (thousands of
tasks) as the scheduler ends up having high long tail scheduling
iteration latencies. The problem gets worse depending on the scheduling
interval, for example, every 5 seconds.

Trying this out in production yields consistent double-digit millisecond
latencies as opposed to single second peaks from before.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
