### PR TITLE
Add jarUrl field to CompactJobInfo

### DIFF
--- a/server/src/main/java/io/mantisrx/master/api/akka/route/proto/JobClusterProtoAdapter.java
+++ b/server/src/main/java/io/mantisrx/master/api/akka/route/proto/JobClusterProtoAdapter.java
@@ -423,6 +423,7 @@ public class JobClusterProtoAdapter {
 
         return new CompactJobInfo(
             jm.getJobId(),
+            (jm.getJarUrl() != null) ? jm.getJarUrl().toString() : "",
             jm.getSubmittedAt(),
             jm.getUser(),
             jm.getState(),

--- a/server/src/main/java/io/mantisrx/server/master/http/api/CompactJobInfo.java
+++ b/server/src/main/java/io/mantisrx/server/master/http/api/CompactJobInfo.java
@@ -36,6 +36,7 @@ public class CompactJobInfo {
     private final String jobId;
     private final long submittedAt;
     private final String user;
+    private final String jarUrl;
     private final MantisJobState state;
     private final MantisJobDurationType type;
     private final int numStages;
@@ -48,6 +49,7 @@ public class CompactJobInfo {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public CompactJobInfo(
             @JsonProperty("jobID") String jobId,
+            @JsonProperty("jarUrl") String jarUrl,
             @JsonProperty("submittedAt") long submittedAt,
             @JsonProperty("user") String user,
             @JsonProperty("state") MantisJobState state,
@@ -60,6 +62,7 @@ public class CompactJobInfo {
             @JsonProperty("labels") List<Label> labels
     ) {
         this.jobId = jobId;
+        this.jarUrl = jarUrl;
         this.submittedAt = submittedAt;
         this.user = user;
         this.state = state;
@@ -91,8 +94,9 @@ public class CompactJobInfo {
                     stSmry.put(w.getState() + "", prevVal + 1);
             }
         }
+        String artifact = job.getJarUrl().toString();
         return new CompactJobInfo(
-                job.getJobId(), job.getSubmittedAt(), job.getUser(), job.getState(),
+                job.getJobId(), artifact, job.getSubmittedAt(), job.getUser(), job.getState(),
                 job.getSla().getDurationType(), job.getNumStages(), workers, totCPUs, totMem, stSmry, job.getLabels()
         );
     }
@@ -132,6 +136,8 @@ public class CompactJobInfo {
     public double getTotMemory() {
         return totMemory;
     }
+
+    public String getJarUrl() { return jarUrl; }
 
     public Map<String, Integer> getStatesSummary() {
         return statesSummary;


### PR DESCRIPTION
### Context

artifact information is useful to have even in the compact view. Currently, users have to fetch the detailed jobInfo to get this data. With large number of jobs this payload can get very large.

### Checklist

- [ x] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
